### PR TITLE
Uniswap credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
     "postcss": "^8.2.6",
     "svelte-preprocess": "^4.6.9",
     "tailwindcss": "^2.0.3",
-<<<<<<< HEAD
     "uuid": "^8.3.2",
-=======
->>>>>>> Finalized qualifications checks for uniswap UI, moved uniswap utils to match ethr branch
     "graphql": "^15.5.0",
     "graphql-request": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "postcss": "^8.2.6",
     "svelte-preprocess": "^4.6.9",
     "tailwindcss": "^2.0.3",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "graphql": "^15.5.0",
+    "graphql-request": "^3.4.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "postcss": "^8.2.6",
     "svelte-preprocess": "^4.6.9",
     "tailwindcss": "^2.0.3",
+<<<<<<< HEAD
     "uuid": "^8.3.2",
+=======
+>>>>>>> Finalized qualifications checks for uniswap UI, moved uniswap utils to match ethr branch
     "graphql": "^15.5.0",
     "graphql-request": "^3.4.0"
   },

--- a/src/components/QualifiedCredentialButton.svelte
+++ b/src/components/QualifiedCredentialButton.svelte
@@ -18,13 +18,13 @@
 	{#if statusEntry.status[credentialKey].cached}
 		<button on:click={issueFunc}>Issue {credentialTitle} Credential</button>
 	{:else if !statusEntry.live && statusEntry.status[credentialKey].qualified}
-		<button disabled={true}>Create Trade Activity Credential</button>
+		<button disabled={true}>Create {credentialTitle} Credential</button>
 		<p style="color:white">
 			Cannot create new credential with disconnected wallet
 		</p>
 		<!-- TODO: Add qualifications check here -->
 	{:else if statusEntry.status[credentialKey].qualified}
-		<button on:click={createFunc}>Create Trade Activity Credential</button>
+		<button on:click={createFunc}>Create {credentialTitle} Credential</button>
 	{:else if statusEntry.status[credentialKey].qualified_err}
 		<p style="color:white;">
 			Does not qualify for {credentialTitle} Credential: {statusEntry.status[credentialKey]

--- a/src/components/QualifiedCredentialButton.svelte
+++ b/src/components/QualifiedCredentialButton.svelte
@@ -1,34 +1,33 @@
 <script>
-	import { onMount } from "svelte";
+	// import { onMount } from "svelte";
 
+	// The key that the credential's base is stored at in the statusEntry
 	export let credentialKey;
+	// The title of the credential to be used in the UI
 	export let credentialTitle;
+	// An object contiaining the qualification status of the the given wallet
 	export let statusEntry;
 
-	export let issueFunc;
+	// the function to call when caching a credential for future use
 	export let createFunc;
-	onMount(() => {
-		console.log(credentialKey);
-		console.log(credentialTitle);
-		console.log(statusEntry);
-	});
+	// the function to call when issuing a cached credential
+	export let issueFunc;
 </script>
 
-<div>
-	{#if statusEntry.status[credentialKey].cached}
-		<button on:click={issueFunc}>Issue {credentialTitle} Credential</button>
-	{:else if !statusEntry.live && statusEntry.status[credentialKey].qualified}
-		<button disabled={true}>Create {credentialTitle} Credential</button>
-		<p style="color:white">
-			Cannot create new credential with disconnected wallet
-		</p>
-		<!-- TODO: Add qualifications check here -->
-	{:else if statusEntry.status[credentialKey].qualified}
-		<button on:click={createFunc}>Create {credentialTitle} Credential</button>
-	{:else if statusEntry.status[credentialKey].qualified_err}
-		<p style="color:white;">
-			Does not qualify for {credentialTitle} Credential: {statusEntry.status[credentialKey]
-				.qualified_err}
-		</p>
-	{/if}
-</div>
+{#if statusEntry.status[credentialKey].cached}
+	<button on:click={issueFunc}>Issue {credentialTitle} Credential</button>
+{:else if !statusEntry.live && statusEntry.status[credentialKey].qualified}
+	<button disabled={true}>Create {credentialTitle} Credential</button>
+	<p style="color:white">
+		Cannot create new credential with disconnected wallet
+	</p>
+	<!-- TODO: Add qualifications check here -->
+{:else if statusEntry.status[credentialKey].qualified}
+	<button on:click={createFunc}>Create {credentialTitle} Credential</button>
+{:else if statusEntry.status[credentialKey].qualified_err}
+	<p style="color:white;">
+		Does not qualify for {credentialTitle} Credential: {statusEntry.status[
+			credentialKey
+		].qualified_err}
+	</p>
+{/if}

--- a/src/components/QualifiedCredentialButton.svelte
+++ b/src/components/QualifiedCredentialButton.svelte
@@ -1,5 +1,6 @@
 <script>
 	// import { onMount } from "svelte";
+	import SecondaryButton from "./SecondaryButton.svelte";
 
 	// The key that the credential's base is stored at in the statusEntry
 	export let credentialKey;
@@ -15,19 +16,23 @@
 </script>
 
 {#if statusEntry.status[credentialKey].cached}
-	<button on:click={issueFunc}>Issue {credentialTitle} Credential</button>
+	<SecondaryButton
+		onClick={issueFunc}
+		label={`Issue ${credentialTitle} Credential`}
+	/>
 {:else if !statusEntry.live && statusEntry.status[credentialKey].qualified}
-	<button disabled={true}>Create {credentialTitle} Credential</button>
-	<p style="color:white">
-		Cannot create new credential with disconnected wallet
-	</p>
-	<!-- TODO: Add qualifications check here -->
+	<SecondaryButton 
+		disabled={true}
+		label={`Connect to create ${credentialTitle} Credential`}
+	/>
 {:else if statusEntry.status[credentialKey].qualified}
-	<button on:click={createFunc}>Create {credentialTitle} Credential</button>
+	<SecondaryButton 
+		onClick={createFunc}
+		label={`Create ${credentialTitle} Credential`}
+	/>
 {:else if statusEntry.status[credentialKey].qualified_err}
-	<p style="color:white;">
-		Does not qualify for {credentialTitle} Credential: {statusEntry.status[
-			credentialKey
-		].qualified_err}
-	</p>
+	<SecondaryButton 
+		disabled={true}
+		label={`Does not qualify for ${credentialTitle} Credential`}
+	/>
 {/if}

--- a/src/components/QualifiedCredentialButton.svelte
+++ b/src/components/QualifiedCredentialButton.svelte
@@ -1,0 +1,34 @@
+<script>
+	import { onMount } from "svelte";
+
+	export let credentialKey;
+	export let credentialTitle;
+	export let statusEntry;
+
+	export let issueFunc;
+	export let createFunc;
+	onMount(() => {
+		console.log(credentialKey);
+		console.log(credentialTitle);
+		console.log(statusEntry);
+	});
+</script>
+
+<div>
+	{#if statusEntry.status[credentialKey].cached}
+		<button on:click={issueFunc}>Issue {credentialTitle} Credential</button>
+	{:else if !statusEntry.live && statusEntry.status[credentialKey].qualified}
+		<button disabled={true}>Create Trade Activity Credential</button>
+		<p style="color:white">
+			Cannot create new credential with disconnected wallet
+		</p>
+		<!-- TODO: Add qualifications check here -->
+	{:else if statusEntry.status[credentialKey].qualified}
+		<button on:click={createFunc}>Create Trade Activity Credential</button>
+	{:else if statusEntry.status[credentialKey].qualified_err}
+		<p style="color:white;">
+			Does not qualify for {credentialTitle} Credential: {statusEntry.status[credentialKey]
+				.qualified_err}
+		</p>
+	{/if}
+</div>

--- a/src/components/SecondaryButton.svelte
+++ b/src/components/SecondaryButton.svelte
@@ -2,12 +2,16 @@
     export let label;
     export let icon;
     export let href;
+    export let onClick;
+    export let disabled;
 </script>
 
 <a {href} class="max-w-sm mx-auto my-2 h-16 w-full">
     <button
         class="text-white py-4 text-left rounded-2xl font-semibold flex items-center h-16 w-full"
         style="background: linear-gradient(270deg, #8743FF 0%, #4136F1 100%); box-shadow: 0px 15px 30px 0px rgba(20, 102, 204, 0.40);"
+        disabled={disabled}
+        on:click={onClick}
     >
         {#if icon}
             <div class="w-24 flex justify-center">

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -272,50 +272,122 @@
 			live_all_verified: {
 				live: true,
 				status: {
-					activity: true,
-					liquidity: true,
-					sybil: true,
+					activity: {
+						cached: true,
+						qualified: true,
+						qualified_check: false,
+					},
+					liquidity: {
+						cached: true,
+						qualified: true,
+						qualified_check: false,
+					},
+					sybil: {
+						cached: true,
+						qualified: true,
+						qualified_check: false,
+					},
 				},
 			},
 			live_none_verified: {
 				live: true,
 				status: {
-					activity: false,
-					liquidity: false,
-					sybil: false,
+					activity: {
+						cached: false,
+						qualified: true,
+						qualified_check: false,
+					},
+					liquidity: {
+						cached: false,
+						qualified: true,
+						qualified_check: false,
+					},
+					sybil: {
+						cached: false,
+						qualified: true,
+						qualified_check: false,
+					},
 				},
 			},
 			live_random: {
 				live: true,
 				status: {
-					activity: rActive,
-					liquidity: rLiquid,
-					sybil: rSybil,
+					activity: {
+						cached: rActive,
+						qualified: true,
+						qualified_check: false,
+					},
+					liquidity: {
+						cached: rLiquid,
+						qualified: true,
+						qualified_check: false,
+					},
+					sybil: {
+						cached: rSybil,
+						qualified: true,
+						qualified_check: false,
+					},
 				},
 			},
 			cached_all_verified: {
 				live: false,
 				status: {
-					activity: true,
-					liquidity: true,
-					sybil: true,
+					activity: {
+						cached: true,
+						qualified: true,
+						qualified_check: false,
+					},
+					liquidity: {
+						cached: true,
+						qualified: true,
+						qualified_check: false,
+					},
+					sybil: {
+						cached: true,
+						qualified: true,
+						qualified_check: false,
+					},
 				},
 			},
 			cached_none_verified: {
 				live: false,
 				status: {
-					activity: false,
-					liquidity: false,
-					sybil: false,
+					activity: {
+						cached: false,
+						qualified: true,
+						qualified_check: false,
+					},
+					liquidity: {
+						cached: false,
+						qualified: true,
+						qualified_check: false,
+					},
+					sybil: {
+						cached: false,
+						qualified: true,
+						qualified_check: false,
+					},
 				},
 			},
 
 			cached_random: {
 				live: false,
 				status: {
-					activity: rActive,
-					liquidity: rLiquid,
-					sybil: rSybil,
+					activity: {
+						cached: rActive,
+						qualified: true,
+						qualified_check: false,
+					},
+					liquidity: {
+						cached: rLiquid,
+						qualified: true,
+						qualified_check: false,
+					},
+					sybil: {
+						cached: rSybil,
+						qualified: true,
+						qualified_check: false,
+					},
 				},
 			},
 		};
@@ -476,9 +548,16 @@
 			}}>Start Debug</button
 		>
 	</div>
+	<!-- TODO: On blur, test for qualifications. -->
 	<div>
 		<label for="currentAddress">Choose An Address</label>
-		<select bind:value={currentAddress} name="currentAddress">
+		<select
+			bind:value={currentAddress}
+			on:change={() => {
+				console.log("Look up qualifications here");
+			}}
+			name="currentAddress"
+		>
 			<option value="">No Address Selected</option>
 			{#each Object.keys(uniswapVCStatusMap) as wallet}
 				{#if uniswapVCStatusMap[wallet].live}
@@ -515,11 +594,12 @@
 							alert("Issue activity credential");
 						}}>Issue Trade Activity Credential</button
 					>
-				{:else if !uniswapVCStatusMap[currentAddress].live && uniswapVCStatusMap[currentAddress].status.activity.cached}
+				{:else if !uniswapVCStatusMap[currentAddress].live && !uniswapVCStatusMap[currentAddress].status.activity.cached}
 					<button disabled={true}>Create Trade Activity Credential</button>
 					<p style="color:white">
 						Cannot create new credential with disconnected wallet
 					</p>
+				<!-- TODO: Add qualifications check here -->
 				{:else}
 					<button
 						on:click={() => {
@@ -536,11 +616,12 @@
 							alert("Issue liquidity credential");
 						}}>Issue LP Credential</button
 					>
-				{:else if !uniswapVCStatusMap[currentAddress].live}
+				{:else if !uniswapVCStatusMap[currentAddress].live && !uniswapVCStatusMap[currentAddress].status.liquidity.cached}
 					<button disabled>Create LP Credential</button>
 					<p style="color:white">
 						Cannot create new credential with disconnected wallet
 					</p>
+				<!-- TODO: Add qualifications check here -->
 				{:else}
 					<button
 						on:click={() => {
@@ -557,7 +638,7 @@
 							alert("Issue sybil credential");
 						}}>Issue Sybil Credential</button
 					>
-				{:else if !uniswapVCStatusMap[currentAddress].live}
+				{:else if !uniswapVCStatusMap[currentAddress].live && !uniswapVCStatusMap[currentAddress].status.liquidity.cached}
 					<button disabled>Create Trade Sybil Credential</button>
 					<p style="color:white">
 						Cannot create new credential with disconnected wallet

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -7,40 +7,13 @@
 
     /*
 	import { createSybilVC } from "../util/Uniswap";
-	import { request, gql } from "graphql-request";
 
-	/*
-		interface ActivityOpts {
-			// Only include trades over a certain amount of ETH
-			// defaults to 0.
-			per_trade_min?: number,
-			// How many days to go back to meet the threshold
-			// defaults to 0, which means no limit.
-			total_days_back?: number,
-			// The total ETH that must have been moved
-			// defaults to 0.
-			total_trade_min?: number,
-			// number of trades to meet the threshold
-			trade_count?: number,
-		};
-	*/
-	export let activityThreshold;
+	// Assume top level passes a ethereum object with
+	// a provider which has one ore more wallets.
+	export let ethereum;
 
-	/*
-		interface LiquidityOpts {
-			// How much liquidity must be provided.
-			liquidity_eth: number,
-			// How many days to go back to meet the threshold
-			// defaults to 0, which means no limit.
-			total_days_back?: number,
-		};
-	*/
-	export let liquidityThreshold;
-
-	// Assume top level will pass us threshold
-	// Assume top level passes a web3 object with
-	// a provider which has a wallet.
-	export let web3;
+	// TODO: Have lists of thresholds passed down for modular VC qualifications.
+	// Adjust uniswap.js to match.
 
 	/*
         The local storage representation of credentials.
@@ -91,20 +64,8 @@
 	// Get auto complete help when using local storage.
 	const vcLocalStorageKey = "degenissuer_verified_credentials";
 
-	// GQL query makers:
-	// TODO: Add start date.
-	let activityQuery = gql`
-		query exchanges(where: {tokenAddress: $wallet}) {
-			startTime
-			tokenAddress
-			tokenSymbol
-			buyTokenCount
-			sellTokenCount
-			tradeVolumeEth
-		}`;
-
 	// Lifecycle
-	const onLoad = () => {
+	const onLoad = async () => {
 		// object of cached Uniswap Sybil credentials
 		let cache;
 		// JSON String of cache, or null
@@ -119,7 +80,7 @@
 		}
 
 		// Connected accounts vs...
-		let liveAccounts = web3.eth.getAccounts();
+		let liveAccounts = await getConnectedWallets();
 		// ...cached accounts as an array
 		let cachedAccounts = Object.keys(cache);
 		// to be assigned to uniswapVCStatusMap after processing
@@ -221,6 +182,18 @@
 			"liquidity",
 			"sybil",
 		]);
+	};
+
+	// Ethereum Account Interactions
+	const getConnectedWallets = async () => {
+		try {
+			let wallets = await ethereum.request({ method: "eth_requestAccounts" });
+			return wallets;
+		} catch (err) {
+			// TODO: Handle this better?
+			console.error(err);
+			return [];
+		}
 	};
 
 	// VC interactions

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -7,6 +7,11 @@
     // a provider which has a wallet.
     export let web3;
 
+    // TODO: Create Drop-down style, with both cached and live accounts
+    // If selected address is live, and does not have a sybil VC show 
+    // button, rather than iterating over them.
+    // Then can match Marco's UI much closer, when the time comes.
+
     // Accounts in local storage the for the user, but not being shown
     // in the web3 object
     $: cachedAccounts = [];
@@ -183,7 +188,7 @@
             }
 
             return [true, entry];
-        } catch (err) {
+        } catch (_err) {
             // Could use err here, or is it better to be vague?
             return [false, "Error in Uniswap Sybil Verification"];
         }
@@ -274,7 +279,7 @@
     {#if liveAccounts.length || cachedAccounts.length}
         <!-- TODO: An each + concat (or dup?) here -->
         <div class="btn-group">
-            <input />
+            <p>TODO: Make this a drop-down of active accounts</p>
             <button>Issue 30-Day History</button>
             <button>Issue LP History</button>
             <a href="/"><button>Back</button></a>

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -589,6 +589,7 @@
 		{:else}
 			<!-- TODO ITER OVER STATUS TO CHANGE BUTTON STATE.-->
 			<div class="btn-group">
+			  <!-- TODO: Restore if history display is desire/implemented
 				<button
 					on:click={() => {
 						// TODO: IMPLEMENT
@@ -601,6 +602,7 @@
 						alert("Turn into Link");
 					}}>Show 30-Day LP History</button
 				>
+				-->
 
 				<QualifiedCredentialButton
 					credentialKey="activity"

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -2,10 +2,288 @@
     import BaseLayout from "../components/BaseLayout.svelte";
     import Input from "../components/Input.svelte";
     import SecondaryButton from "../components/SecondaryButton.svelte";
+
+    // Assume top level passes a web3 object with
+    // a provider which has a wallet.
+    export let web3;
+
+    // Accounts in local storage the for the user, but not being shown
+    // in the web3 object
+    $: cachedAccounts = [];
+    // Held in local storage, keys are addresses,
+    // values are verfied credentials
+    $: cachedSybilCredentialMap = {};
+    // UI error message.
+    $: errorMessage = "";
+    // Connected accounts. Maybe split into unlocked accounts.
+    $: liveAccounts = [];
+    // UI control.
+    $: showSybilVerify = false;
+    // Connect wallets not shown in the cachedSybilCredentialMap
+    // used to generate the verification UI.
+    $: unverifiedSybilWalletMap = {};
+
+    // Get auto complete help when using local storage.
+    const sybilKey = "uniswap_sybil_verified_credentials";
+
+    // Lifecycle
+    const onLoad = () => {
+        // to be assigned to unverifiedSybilWalletMap
+        let unverifiedMap = {};
+
+        // object of cached Uniswap Sybil credentials
+        let cached;
+        // JSON String of cached, or null
+        let cachedStr = localStorage.getItem(sybilKey);
+
+        // On first load, or after clearing of storage.
+        if (!cachedStr) {
+            cached = {};
+            localStorage.setItem(sybilKey, JSON.stringify(cached));
+        } else {
+            cached = JSON.parse(cachedStr);
+        }
+
+        // force a UI update.
+        cachedSybilCredentialMap = cached;
+
+        // Connected accounts vs...
+        liveAccounts = web3.eth.getAccounts();
+        // ...cached accounts as an array
+        tempCachedAccounts = cachedSybilCredentialMap.keys();
+
+        // TODO: Test if accounts are unlocked, then differentiate in the UI.
+        for (let i = 0, x = liveAccounts.length; i < x; i++) {
+            let wallet = liveAccounts[i];
+
+            let cachedVC = cachedSybilCredentialMap[wallet];
+            if (cachedVC) {
+                // Drop live accounts from cached accounts.
+                tempCachedAccounts = tempCachedAccounts.filter(
+                    (x) => x !== wallet
+                );
+            } else {
+                // Add verify UI controls.
+                unverifiedMap[wallet] = {
+                    // UI Controls.
+                    errorMessage: "",
+                    loading: false,
+                    wallet: wallet,
+                };
+            }
+        }
+
+        // force the UI update.
+        unverifiedSybilWalletMap = unverifiedMap;
+        cachedAccounts = tempCachedAccounts;
+
+        if (!liveAccounts.length) {
+            errorMessage = "No connected Ethereum accounts currently detected";
+        }
+    };
+
+    // UI logic
+    const toggleSybilCreate = () => {
+        showSybilVerify = !showSybilVerify;
+    };
+
+    // VC interactions
+    const sybilVerifyEvent = (walletState) => {
+        if (!walletState || typeof walletState !== object) {
+            errorMessage = `App State Error, called without walletState`;
+            return;
+        }
+
+        walletState.loading = true;
+
+        // make signing function block and have predictable fail state.
+        const signingFn = async (data) => {
+            try {
+                let result = await web3.eth.sign(data, walletState.wallet);
+                return [true, result];
+            } catch (err) {
+                return [false, err];
+            }
+        };
+
+        // retrieve the Sybil list from the network, find the entry
+        // in the sybil list, hopefully.
+        let [success, vc] = createSybilVC(walletState.wallet, signingFn);
+        if (!success) {
+            walletState.errorMessage = vc;
+            walletState.loading = false;
+            return;
+        }
+
+        // Update the cache.
+        cachedSybilCredentialMap[walletState.wallet] = vc;
+        localStorage.setItem(
+            sybilKey,
+            JSON.stringify(cachedSybilCredentialMap)
+        );
+
+        // remove from unverifiedMap
+        let tempUnverifiedMap = {};
+        // We could object delete, but Chrome perf isn't fond of that.
+        unverifiedSybilWalletMap.keys().forEach((key) => {
+            if (key !== walletState.wallet) {
+                tempUnverifiedMap[key] = unverifiedSybilWalletMap[key];
+            }
+        });
+
+        // force UI update
+        unverifiedSybilWalletMap = tempUnverifiedMap;
+        cachedSybilCredentialMap = JSON.parse(localStorage.getItem(sybilKey));
+    };
+
+    const createSybilVC = async (wallet, signingFn) => {
+        let entry;
+        try {
+            entry = await sybilVerifyRequest(wallet);
+        } catch (err) {
+            let errorMsg = `Failed to verify wallet: ${err}`;
+            return [false, errorMsg];
+        }
+
+        let proof;
+        [success, proof] = signingFn(JSON.stringify(credentialSubject));
+        // Only fails if account is locked.
+        if (!success) {
+            return [false, proof];
+        }
+
+        let vc = makeSybilCredential(wallet, entry, proof);
+
+        vcMap[wallet] = vc;
+        localStorage.setItem(sybilKey, JSON.stringiify(vcMap));
+
+        return [true, vc];
+    };
+
+    // Currently uses Uniswap's list.
+    // Could change to a method that directory queries twitter from tweetID.
+    const sybilVerifyRequest = async (wallet) => {
+        try {
+            let res = await fetch(
+                "https://raw.githubusercontent.com/Uniswap/sybil-list/master/verified.json"
+            );
+
+            if (!res.ok || res.status !== 200) {
+                throw "Bad response from Sybil List";
+            }
+
+            let json = await res.json();
+            if (!json || typeof json !== "object") {
+                throw "Bad response from Sybil List";
+            }
+
+            let entry = json[wallet];
+            if (!isValidSybilEntry(entry)) {
+                throw "Valid entry not found in Sybil List";
+            }
+
+            return [true, entry];
+        } catch (err) {
+            // Could use err here, or is it better to be vague?
+            return [false, "Error in Uniswap Sybil Verification"];
+        }
+    };
+
+    const isValidSybilEntry = (entry) => {
+        let isObject = entry && typeof entry === "object";
+        if (!isObject) {
+            return false;
+        }
+
+        let hasTwitterEntry =
+            entry.twitter && typeof entry.twitter === "object";
+        if (!hasTwitterEntry) {
+            return false;
+        }
+
+        let { twitter } = entry;
+
+        let hasTimestamp =
+            twitter.timestamp && typeof twitter.timestamp === "number";
+        let hasTweetID = twitter.tweetID && typeof twitter.tweetID === "string";
+        let hasHandle = twitter.handle && typeof twitter.handle === "string";
+
+        return hasTimestamp && hasTweetID && hasHandle;
+    };
+
+    const makeSybilCredential = (wallet, cred, proof) => {
+        let credentialSubject = {
+            id: `did:ethr:${wallet}`,
+            sybil: cred,
+        };
+
+        let vc = {
+            "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                // TODO: Add specific context?
+            ],
+            // !NOTE What does this need to be?
+            // id: "http://example.edu/credentials/3732",
+            issuer: credentialSubject.id,
+            type: ["VerifiableCredential", "UniswapSybilCredential"],
+            credentialSubject: credentialSubject,
+            proof: proof,
+        };
+
+        return vc;
+    };
+
 </script>
 
-<BaseLayout title="Uniswap Credentials" icon="/uniswap.svg">
-    <Input />
-    <SecondaryButton label="Issue 30-Day History" />
-    <SecondaryButton label="Issue LP History" />
-</BaseLayout>
+<h2>Uniswap Credentials</h2>
+<main>
+    {#if errorMessage}
+        <div class="error-container">
+            <p>{errorMessage}</p>
+        </div>
+    {/if}
+    {#if unverifiedSybilWalletMap.keys().length}
+        <div>
+            <p>
+                Detected wallets without <a
+                    href="https://sybil.org/#/delegates/uniswap"
+                    >Uniswap Sybil</a
+                > associated Verified Credential.
+            </p>
+            <button onclick={toggleSybilCreate}
+                >{showSybilVerify ? "Hide" : "Show Unverified wallets"}</button
+            >
+            {#if showSybilVerify}
+                <p>
+                    Note: Assumes the targeted wallet(s) has already followed
+                    the process to be approved by Uniswap
+                </p>
+                {#each unverifiedSybilWalletMap as walletState}
+                    <div>
+                        <p>{walletState.wallet}</p>
+                        <button
+                            onclick={() => {
+                                sybilVerifyEvent(walletState);
+                            }}>Verify</button
+                        >
+                    </div>
+                {/each}
+            {/if}
+        </div>
+    {/if}
+    {#if liveAccounts.length || cachedAccounts.length}
+        <!-- TODO: An each + concat (or dup?) here -->
+        <div class="btn-group">
+            <input />
+            <button>Issue 30-Day History</button>
+            <button>Issue LP History</button>
+            <a href="/"><button>Back</button></a>
+        </div>
+    {/if}
+
+    <BaseLayout title="Uniswap Credentials" icon="/uniswap.svg">
+        <Input />
+        <SecondaryButton label="Issue 30-Day History" />
+        <SecondaryButton label="Issue LP History" />
+    </BaseLayout>
+</main>

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -7,6 +7,7 @@
 
     /*
 	import { createSybilVC } from "../util/Uniswap";
+	import { request, gql } from "graphql-request";
 
 	/*
 		interface ActivityOpts {
@@ -89,6 +90,18 @@
 
 	// Get auto complete help when using local storage.
 	const vcLocalStorageKey = "degenissuer_verified_credentials";
+
+	// GQL query makers:
+	// TODO: Add start date.
+	let activityQuery = gql`
+		query exchanges(where: {tokenAddress: $wallet}) {
+			startTime
+			tokenAddress
+			tokenSymbol
+			buyTokenCount
+			sellTokenCount
+			tradeVolumeEth
+		}`;
 
 	// Lifecycle
 	const onLoad = () => {
@@ -403,136 +416,7 @@
 
 <h2>Uniswap Credentials</h2>
 <main>
-<<<<<<< HEAD
-    {#if errorMessage}
-        <div class="error-container">
-            <p style="color:red">{errorMessage}</p>
-        </div>
-    {/if}
-    <!-- TODO: REMOVE THIS AS DEBUG  -->
-    <div>
-        <p style="color:red">Debug Mock Data</p>
-        <button
-            on:click={() => {
-                console.log("IN ON CLICK");
-                debugUIData();
-            }}>Start Debug</button
-        >
-    </div>
-    <div>
-        <label for="currentAddress">Choose An Address</label>
-        <select bind:value={currentAddress} name="currentAddress">
-            <option value="">No Address Selected</option>
-            {#each Object.keys(uniswapVCStatusMap) as wallet}
-                {#if uniswapVCStatusMap[wallet].live}
-                    <option value={wallet}>{wallet}</option>
-                {:else}
-                    <option value={wallet}>{wallet} (Not Connected)</option>
-                {/if}
-            {/each}
-        </select>
-    </div>
-    {#if currentAddress}
-        {#if loading}
-            <p>Updating...</p>
-        {:else}
-            <!-- TODO ITER OVER STATUS TO CHANGE BUTTON STATE.-->
-            <div class="btn-group">
-                <button
-                    on:click={() => {
-                        // TODO: IMPLEMENT
-                        alert("Turn into Link");
-                    }}>Show 30-Day Trade History</button
-                >
-                <button
-                    on:click={() => {
-                        // TODO: IMPLEMENT
-                        alert("Turn into Link");
-                    }}>Show 30-Day LP History</button
-                >
 
-                {#if uniswapVCStatusMap[currentAddress].status.activity}
-                    <button
-                        on:click={() => {
-                            // TODO: IMPLEMENT
-                            alert("Issue activity credential");
-                        }}>Issue Trade Activity Credential</button
-                    >
-                {:else if !uniswapVCStatusMap[currentAddress].live}
-                    <button disabled={true}
-                        >Create Trade Activity Credential</button
-                    >
-                    <p style="color:white">
-                        Cannot create new credential with disconnected wallet
-                    </p>
-                {:else}
-                    <button
-                        on:click={() => {
-                            // TODO: IMPLEMENT
-                            alert(
-                                "Query Uniswap API then Create activity credential"
-                            );
-                        }}>Create Trade Activity Credential</button
-                    >
-                {/if}
-
-                {#if uniswapVCStatusMap[currentAddress].status.liquidity}
-                    <button
-                        on:click={() => {
-                            // TODO: IMPLEMENT
-                            alert("Issue liquidity credential");
-                        }}>Issue LP Credential</button
-                    >
-                {:else if !uniswapVCStatusMap[currentAddress].live}
-                    <button disabled>Create LP Credential</button>
-                    <p style="color:white">
-                        Cannot create new credential with disconnected wallet
-                    </p>
-                {:else}
-                    <button
-                        on:click={() => {
-                            // TODO: IMPLEMENT
-                            alert(
-                                "Query Uniswap API then Create liquidity credential"
-                            );
-                        }}>Create LP Credential</button
-                    >
-                {/if}
-
-                {#if uniswapVCStatusMap[currentAddress].status.sybil}
-                    <button
-                        on:click={() => {
-                            // TODO: IMPLEMENT
-                            alert("Issue sybil credential");
-                        }}>Issue Sybil Credential</button
-                    >
-                {:else if !uniswapVCStatusMap[currentAddress].live}
-                    <button disabled>Create Trade Sybil Credential</button>
-                    <p style="color:white">
-                        Cannot create new credential with disconnected wallet
-                    </p>
-                {:else}
-                    <button
-                        on:click={() => {
-                            // TODO: IMPLEMENT
-                            issueSybilVC(currentAddress);
-                        }}>Create Trade Sybil Credential</button
-                    >
-                {/if}
-            </div>
-        {/if}
-    {/if}
-<<<<<<< HEAD
-
-    <BaseLayout title="Uniswap Credentials" icon="/uniswap.svg">
-        <Input />
-        <SecondaryButton label="Issue 30-Day History" />
-        <SecondaryButton label="Issue LP History" />
-    </BaseLayout>
-=======
-    <a href="/"><button>Back</button></a>
->>>>>>> adds working per-ethereum-address ui, uniswap sybil checking, and debug data to allow simple testing
-=======
 	{#if errorMessage}
 		<div class="error-container">
 			<p style="color:red">{errorMessage}</p>
@@ -599,7 +483,7 @@
 					<p style="color:white">
 						Cannot create new credential with disconnected wallet
 					</p>
-				<!-- TODO: Add qualifications check here -->
+					<!-- TODO: Add qualifications check here -->
 				{:else}
 					<button
 						on:click={() => {
@@ -621,7 +505,7 @@
 					<p style="color:white">
 						Cannot create new credential with disconnected wallet
 					</p>
-				<!-- TODO: Add qualifications check here -->
+					<!-- TODO: Add qualifications check here -->
 				{:else}
 					<button
 						on:click={() => {
@@ -654,6 +538,11 @@
 			</div>
 		{/if}
 	{/if}
+
+    <BaseLayout title="Uniswap Credentials" icon="/uniswap.svg">
+        <Input />
+        <SecondaryButton label="Issue 30-Day History" />
+        <SecondaryButton label="Issue LP History" />
+    </BaseLayout>
 	<a href="/"><button>Back</button></a>
->>>>>>> updated to include qualifications in state to best show the UI for live accounts
 </main>

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -299,8 +299,6 @@
 	};
 
 	const cacheSybilVC = async (wallet) => {
-		console.log(uniswapVCStatusMap);
-		console.log(wallet);
 		let sybilEntry = uniswapVCStatusMap[wallet]?.status?.sybil?.qualified_proof;
 		if (!sybilEntry) {
 			errorMessage = "Error creating Sybil Credential";
@@ -524,7 +522,6 @@
 		};
 
 		uniswapVCStatusMap = dummyCache;
-		console.log(uniswapVCStatusMap);
 	};
 </script>
 
@@ -540,7 +537,6 @@
 		<p style="color:red">Debug Mock Data</p>
 		<button
 			on:click={() => {
-				console.log("IN ON CLICK");
 				debugUIData();
 			}}>Start Debug</button
 		>
@@ -551,7 +547,6 @@
 		<select
 			bind:value={currentAddress}
 			on:change={() => {
-				console.log("Look up qualifications here");
 				checkQualifications(currentAddress);
 			}}
 			name="currentAddress"

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -484,6 +484,8 @@
 				},
 			},
 
+			// Two real eth addresses, the first qualifies for Sybil, the second for Activity.
+
 			"0x8d07D225a769b7Af3A923481E1FdF49180e6A265": {
 				live: true,
 				loading: false,

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -547,6 +547,7 @@
 	};
 </script>
 
+<<<<<<< HEAD
 <h2>Uniswap Credentials</h2>
 <main>
 	{#if errorMessage}
@@ -555,6 +556,10 @@
 		</div>
 	{/if}
 	<!-- TODO: REMOVE THIS AS DEBUG  -->
+=======
+<BaseLayout title="Uniswap Credentials" icon="/uniswap.svg">
+	<!-- TODO: REMOVE THIS AS DEBUG 
+>>>>>>> update to use much better ui
 	<div>
 		<p style="color:red">Debug Mock Data</p>
 		<button
@@ -562,48 +567,33 @@
 				debugUIData();
 			}}>Start Debug</button
 		>
-	</div>
-	<!-- TODO: On blur, test for qualifications. -->
-	<div>
-		<label for="currentAddress">Choose An Address</label>
-		<select
-			bind:value={currentAddress}
-			on:change={() => {
-				checkQualifications(currentAddress);
-			}}
-			name="currentAddress"
-		>
-			<option value="">No Address Selected</option>
-			{#each Object.keys(uniswapVCStatusMap) as wallet}
-				{#if uniswapVCStatusMap[wallet].live}
-					<option value={wallet}>{wallet}</option>
-				{:else}
-					<option value={wallet}>{wallet} (Not Connected)</option>
-				{/if}
-			{/each}
-		</select>
-	</div>
+	</div >
+	-->
+
+	{#if errorMessage}
+		<p style="color:red">{errorMessage}</p>
+	{/if}
+	<label for="currentAddress">Choose An Address</label>
+	<select
+		bind:value={currentAddress}
+		on:change={() => {
+			checkQualifications(currentAddress);
+		}}
+		name="currentAddress"
+	>
+		<option value="">No Address Selected</option>
+		{#each Object.keys(uniswapVCStatusMap) as wallet}
+			{#if uniswapVCStatusMap[wallet].live}
+				<option value={wallet}>{wallet}</option>
+			{:else}
+				<option value={wallet}>{wallet} (Not Connected)</option>
+			{/if}
+		{/each}
+	</select>
 	{#if currentAddress}
 		{#if loading || uniswapVCStatusMap[currentAddress].loading}
 			<p style="color:white">Updating...</p>
 		{:else}
-			<!-- TODO ITER OVER STATUS TO CHANGE BUTTON STATE.-->
-			<div class="btn-group">
-			  <!-- TODO: Restore if history display is desire/implemented
-				<button
-					on:click={() => {
-						// TODO: IMPLEMENT
-						alert("Turn into Link");
-					}}>Show 30-Day Trade History</button
-				>
-				<button
-					on:click={() => {
-						// TODO: IMPLEMENT
-						alert("Turn into Link");
-					}}>Show 30-Day LP History</button
-				>
-				-->
-
 				<QualifiedCredentialButton
 					credentialKey="activity"
 					credentialTitle="Trade Activity"
@@ -639,9 +629,9 @@
 						cacheVC(currentAddress, "sybil");
 					}}
 				/>
-			</div>
 		{/if}
 	{/if}
+<<<<<<< HEAD
 
     <BaseLayout title="Uniswap Credentials" icon="/uniswap.svg">
         <Input />
@@ -656,3 +646,6 @@
         <SecondaryButton label="Issue LP History" />
     </BaseLayout>
 </main>
+=======
+</BaseLayout>
+>>>>>>> update to use much better ui

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -547,19 +547,8 @@
 	};
 </script>
 
-<<<<<<< HEAD
-<h2>Uniswap Credentials</h2>
-<main>
-	{#if errorMessage}
-		<div class="error-container">
-			<p style="color:red">{errorMessage}</p>
-		</div>
-	{/if}
-	<!-- TODO: REMOVE THIS AS DEBUG  -->
-=======
 <BaseLayout title="Uniswap Credentials" icon="/uniswap.svg">
 	<!-- TODO: REMOVE THIS AS DEBUG 
->>>>>>> update to use much better ui
 	<div>
 		<p style="color:red">Debug Mock Data</p>
 		<button
@@ -632,21 +621,4 @@
 				/>
 		{/if}
 	{/if}
-<<<<<<< HEAD
-
-    <BaseLayout title="Uniswap Credentials" icon="/uniswap.svg">
-        <Input />
-        <SecondaryButton label="Issue 30-Day History" />
-        <SecondaryButton label="Issue LP History" />
-    </BaseLayout>
-	<a href="/"><button>Back</button></a>
-
-	<BaseLayout title="Uniswap Credentials" icon="/uniswap.svg">
-        <Input />
-        <SecondaryButton label="Issue 30-Day History" />
-        <SecondaryButton label="Issue LP History" />
-    </BaseLayout>
-</main>
-=======
 </BaseLayout>
->>>>>>> update to use much better ui

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -575,6 +575,7 @@
 	{/if}
 	<label for="currentAddress">Choose An Address</label>
 	<select
+		class="text-white p-4 text-left rounded-2xl max-w-sm mx-auto flex items-center h-16 w-full bg-blue-998 border-2 border-blue-997 mb-6"
 		bind:value={currentAddress}
 		on:change={() => {
 			checkQualifications(currentAddress);

--- a/src/routes/Unicred.svelte
+++ b/src/routes/Unicred.svelte
@@ -4,11 +4,44 @@
     import SecondaryButton from "../components/SecondaryButton.svelte";
 
     import { createSybilVC } from "../util/Uniswap";
-    // Assume top level passes a web3 object with
-    // a provider which has a wallet.
-    export let web3;
 
     /*
+	import { createSybilVC } from "../util/Uniswap";
+
+	/*
+		interface ActivityOpts {
+			// Only include trades over a certain amount of ETH
+			// defaults to 0.
+			per_trade_min?: number,
+			// How many days to go back to meet the threshold
+			// defaults to 0, which means no limit.
+			total_days_back?: number,
+			// The total ETH that must have been moved
+			// defaults to 0.
+			total_trade_min?: number,
+			// number of trades to meet the threshold
+			trade_count?: number,
+		};
+	*/
+	export let activityThreshold;
+
+	/*
+		interface LiquidityOpts {
+			// How much liquidity must be provided.
+			liquidity_eth: number,
+			// How many days to go back to meet the threshold
+			// defaults to 0, which means no limit.
+			total_days_back?: number,
+		};
+	*/
+	export let liquidityThreshold;
+
+	// Assume top level will pass us threshold
+	// Assume top level passes a web3 object with
+	// a provider which has a wallet.
+	export let web3;
+
+	/*
         The local storage representation of credentials.
         For now, looks like:
         {
@@ -29,17 +62,17 @@
             }
         }
     */
-    $: cachedCredentialMap = {};
+	$: cachedCredentialMap = {};
 
-    // currentAddress is the focus of the UI
-    $: currentAddress = "";
+	// currentAddress is the focus of the UI
+	$: currentAddress = "";
 
-    // UI error message.
-    $: errorMessage = "";
+	// UI error message.
+	$: errorMessage = "";
 
-    $: loading = false;
+	$: loading = false;
 
-    /* 
+	/*
         An object with eth addresses as keys and this object as values:
         {
             "<address>": {
@@ -52,248 +85,253 @@
             }
         }
     */
-    $: uniswapVCStatusMap = {};
+	$: uniswapVCStatusMap = {};
 
-    // Get auto complete help when using local storage.
-    const vcLocalStorageKey = "degenissuer_verified_credentials";
+	// Get auto complete help when using local storage.
+	const vcLocalStorageKey = "degenissuer_verified_credentials";
 
-    // Lifecycle
-    const onLoad = () => {
-        // object of cached Uniswap Sybil credentials
-        let cache;
-        // JSON String of cache, or null
-        let cachedStr = localStorage.getItem(vcLocalStorageKey);
+	// Lifecycle
+	const onLoad = () => {
+		// object of cached Uniswap Sybil credentials
+		let cache;
+		// JSON String of cache, or null
+		let cachedStr = localStorage.getItem(vcLocalStorageKey);
 
-        // On first load, or after clearing of storage.
-        if (!cachedStr) {
-            cache = {};
-            localStorage.setItem(vcLocalStorageKey, JSON.stringify(cache));
-        } else {
-            cache = JSON.parse(cachedStr);
-        }
+		// On first load, or after clearing of storage.
+		if (!cachedStr) {
+			cache = {};
+			localStorage.setItem(vcLocalStorageKey, JSON.stringify(cache));
+		} else {
+			cache = JSON.parse(cachedStr);
+		}
 
-        // Connected accounts vs...
-        let liveAccounts = web3.eth.getAccounts();
-        // ...cached accounts as an array
-        let cachedAccounts = Object.keys(cache);
-        // to be assigned to uniswapVCStatusMap after processing
-        let statusMap = {};
+		// Connected accounts vs...
+		let liveAccounts = web3.eth.getAccounts();
+		// ...cached accounts as an array
+		let cachedAccounts = Object.keys(cache);
+		// to be assigned to uniswapVCStatusMap after processing
+		let statusMap = {};
 
-        // TODO: Test if accounts are unlocked, then differentiate in the UI.
-        for (let i = 0, x = liveAccounts.length; i < x; i++) {
-            let wallet = liveAccounts[i];
-            let status = uniswapStatusMapEntry(cache, wallet);
+		// TODO: Test if accounts are unlocked, then differentiate in the UI.
+		for (let i = 0, x = liveAccounts.length; i < x; i++) {
+			let wallet = liveAccounts[i];
+			let status = uniswapStatusMapEntry(cache, wallet);
 
-            statusMap[wallet] = {
-                live: true,
-                status: status,
-            };
-        }
+			statusMap[wallet] = {
+				live: true,
+				status: status,
+			};
+		}
 
-        for (let i = 0, x = cachedAccounts.length; i < x; i++) {
-            let wallet = cachedAccounts[i];
-            if (!statusMap[wallet]) {
-                let status = uniswapStatusMapEntry(cache, wallet);
+		for (let i = 0, x = cachedAccounts.length; i < x; i++) {
+			let wallet = cachedAccounts[i];
+			if (!statusMap[wallet]) {
+				let status = uniswapStatusMapEntry(cache, wallet);
 
-                statusMap[wallet] = {
-                    live: false,
-                    status: status,
-                };
-            }
-        }
+				statusMap[wallet] = {
+					live: false,
+					status: status,
+				};
+			}
+		}
 
-        // force the UI update.
-        cachedCredentialMap = cached;
-        uniswapVCStatusMap = statusMap;
+		// force the UI update.
+		cachedCredentialMap = cached;
+		uniswapVCStatusMap = statusMap;
 
-        if (!liveAccounts.length) {
-            errorMessage = "No connected Ethereum accounts currently detected";
-        }
-    };
+		if (!liveAccounts.length) {
+			errorMessage = "No connected Ethereum accounts currently detected";
+		}
+	};
 
-    // cache operations
-    // Given a wallet, a category, and a list of types, returns a status map
-    const createStatusMap = (
-        cache,
-        wallet,
-        credentialCategory,
-        credentialTypeList
-    ) => {
-        let statusMapEntry = { wallet: wallet };
+	// cache operations
+	// Given a wallet, a category, and a list of types, returns a status map
+	const createStatusMap = (
+		cache,
+		wallet,
+		credentialCategory,
+		credentialTypeList
+	) => {
+		let statusMapEntry = {};
 
-        for (let i = 0, n = credentialTypeList; i < n; i++) {
-            let credentialType = credentialTypeList[i];
-            statusMapEntry[credentialType] = hasCredentialType(
-                cache,
-                wallet,
-                credentialCategory,
-                credentialType
-            );
-        }
+		for (let i = 0, n = credentialTypeList; i < n; i++) {
+			let credentialType = credentialTypeList[i];
+			let cached = hasCredentialType(
+				cache,
+				wallet,
+				credentialCategory,
+				credentialType
+			);
 
-        return statusMapEntry;
-    };
+			statusMapEntry[credentialType] = {
+				cached: cached,
+				qualified: cached,
+				qualified_check: false,
+			};
+		}
 
-    const hasCredentialType = (
-        cache,
-        wallet,
-        credentialCategory,
-        credentialType
-    ) => {
-        if (!hasCredentials(cache, wallet, credentialCategory)) {
-            return false;
-        }
+		return statusMapEntry;
+	};
 
-        return !!cache[wallet][credentialCategory][credentialType];
-    };
+	const hasCredentialType = (
+		cache,
+		wallet,
+		credentialCategory,
+		credentialType
+	) => {
+		if (!hasCredentials(cache, wallet, credentialCategory)) {
+			return false;
+		}
 
-    const hasCredentials = (cache, wallet, credentialCategory) => {
-        let isObject = cache && typeof cache === "object";
-        if (!isObject) {
-            return false;
-        }
+		return !!cache[wallet][credentialCategory][credentialType];
+	};
 
-        let hasWallet = cache[wallet];
-        if (!hasWallet) {
-            return false;
-        }
+	const hasCredentials = (cache, wallet, credentialCategory) => {
+		let isObject = cache && typeof cache === "object";
+		if (!isObject) {
+			return false;
+		}
 
-        let hasCredentialType = hasWallet[credentialCategory];
+		let hasWallet = cache[wallet];
+		if (!hasWallet) {
+			return false;
+		}
 
-        return !!hasCredentialType;
-    };
+		let hasCredentialType = hasWallet[credentialCategory];
 
-    const uniswapStatusMapEntry = (cache, wallet) => {
-        return createStatusMap(cache, wallet, "uniswap", [
-            "activity",
-            "liquidity",
-            "sybil",
-        ]);
-    };
+		return !!hasCredentialType;
+	};
 
-    // VC interactions
-    const issueSybilVC = async (wallet) => {
-        if (!wallet || typeof wallet !== "string") {
-            errorMessage = `App State Error, called without wallet`;
-            return;
-        }
+	const uniswapStatusMapEntry = (cache, wallet) => {
+		return createStatusMap(cache, wallet, "uniswap", [
+			"activity",
+			"liquidity",
+			"sybil",
+		]);
+	};
 
-        loading = true;
+	// VC interactions
+	const issueSybilVC = async (wallet) => {
+		if (!wallet || typeof wallet !== "string") {
+			errorMessage = `App State Error, called without wallet`;
+			return;
+		}
 
-        // make signing function block and have predictable fail state.
-        const signingFn = async (data) => {
-            console.log("Here!")
-            try {
-                let result = await web3.eth.sign(data, wallet);
-                return [true, result];
-            } catch (err) {
-                console.log("Here?")
-                return [false, err];
-            }
-        };
+		loading = true;
 
-        // retrieve the Sybil list from the network, find the entry
-        // in the sybil list, hopefully.
-        let [success, vc] = await createSybilVC(wallet, signingFn);
-        if (!success) {
-            errorMessage = vc;
-            loading = false;
-            return;
-        }
+		// make signing function block and have predictable fail state.
+		const signingFn = async (data) => {
+			console.log("Here!");
+			try {
+				let result = await web3.eth.sign(data, wallet);
+				return [true, result];
+			} catch (err) {
+				console.log("Here?");
+				return [false, err];
+			}
+		};
 
-        if (!cachedCredentialMap[wallet]) {
-            cachedCredentialMap[wallet] = {};
-            cachedCredentialMap[wallet].uniswap = {};
-        } else if (!hasCredentials(cachedCredentialMap, wallet, "uniswap")) {
-            cachedCredentialMap[wallet].uniswap = {};
-        }
+		// retrieve the Sybil list from the network, find the entry
+		// in the sybil list, hopefully.
+		let [success, vc] = await createSybilVC(wallet, signingFn);
+		if (!success) {
+			errorMessage = vc;
+			loading = false;
+			return;
+		}
 
-        cachedCredentialMap[wallet].uniswap.sybil = vc;
+		if (!cachedCredentialMap[wallet]) {
+			cachedCredentialMap[wallet] = {};
+			cachedCredentialMap[wallet].uniswap = {};
+		} else if (!hasCredentials(cachedCredentialMap, wallet, "uniswap")) {
+			cachedCredentialMap[wallet].uniswap = {};
+		}
 
-        // Save the update to the cache
-        localStorage.setItem(
-            vcLocalStorageKey,
-            JSON.stringify(cachedCredentialMap)
-        );
+		cachedCredentialMap[wallet].uniswap.sybil = vc;
 
-        // force UI update
-        let tempUniswapMap = uniswapVCStatusMap;
-        tempUniswapMap[wallet].uniswap.sybil = true;
-        uniswapVCStatusMap = tempUniswapMap;
-        cachedCredentialMap = JSON.parse(
-            localStorage.getItem(vcLocalStorageKey)
-        );
-    };
+		// Save the update to the cache
+		localStorage.setItem(
+			vcLocalStorageKey,
+			JSON.stringify(cachedCredentialMap)
+		);
 
-    // TODO: REMOVE, UI Debub mocks:
-    const debugUIData = () => {
-        let rActive = Math.random() < 0.5;
-        let rLiquid = Math.random() < 0.5;
-        let rSybil = Math.random() < 0.5;
+		// force UI update
+		let tempUniswapMap = uniswapVCStatusMap;
+		tempUniswapMap[wallet].uniswap.sybil = true;
+		uniswapVCStatusMap = tempUniswapMap;
+		cachedCredentialMap = JSON.parse(localStorage.getItem(vcLocalStorageKey));
+	};
 
-        let dummyCache = {
-            live_all_verified: {
-                live: true,
-                status: {
-                    activity: true,
-                    liquidity: true,
-                    sybil: true,
-                },
-            },
-            live_none_verified: {
-                live: true,
-                status: {
-                    activity: false,
-                    liquidity: false,
-                    sybil: false,
-                },
-            },
-            live_random: {
-                live: true,
-                status: {
-                    activity: rActive,
-                    liquidity: rLiquid,
-                    sybil: rSybil,
-                },
-            },
-            cached_all_verified: {
-                live: false,
-                status: {
-                    activity: true,
-                    liquidity: true,
-                    sybil: true,
-                },
-            },
-            cached_none_verified: {
-                live: false,
-                status: {
-                    activity: false,
-                    liquidity: false,
-                    sybil: false,
-                },
-            },
+	// TODO: REMOVE, UI Debub mocks:
+	const debugUIData = () => {
+		let rActive = Math.random() < 0.5;
+		let rLiquid = Math.random() < 0.5;
+		let rSybil = Math.random() < 0.5;
 
-            cached_random: {
-                live: false,
-                status: {
-                    activity: rActive,
-                    liquidity: rLiquid,
-                    sybil: rSybil,
-                },
-            },
-        };
+		let dummyCache = {
+			live_all_verified: {
+				live: true,
+				status: {
+					activity: true,
+					liquidity: true,
+					sybil: true,
+				},
+			},
+			live_none_verified: {
+				live: true,
+				status: {
+					activity: false,
+					liquidity: false,
+					sybil: false,
+				},
+			},
+			live_random: {
+				live: true,
+				status: {
+					activity: rActive,
+					liquidity: rLiquid,
+					sybil: rSybil,
+				},
+			},
+			cached_all_verified: {
+				live: false,
+				status: {
+					activity: true,
+					liquidity: true,
+					sybil: true,
+				},
+			},
+			cached_none_verified: {
+				live: false,
+				status: {
+					activity: false,
+					liquidity: false,
+					sybil: false,
+				},
+			},
 
-        console.log("BEFORE");
-        console.log(uniswapVCStatusMap);
-        uniswapVCStatusMap = dummyCache;
+			cached_random: {
+				live: false,
+				status: {
+					activity: rActive,
+					liquidity: rLiquid,
+					sybil: rSybil,
+				},
+			},
+		};
 
-        console.log("AFTER");
-        console.log(uniswapVCStatusMap);
-    };
+		console.log("BEFORE");
+		console.log(uniswapVCStatusMap);
+		uniswapVCStatusMap = dummyCache;
+
+		console.log("AFTER");
+		console.log(uniswapVCStatusMap);
+	};
 </script>
 
 <h2>Uniswap Credentials</h2>
 <main>
+<<<<<<< HEAD
     {#if errorMessage}
         <div class="error-container">
             <p style="color:red">{errorMessage}</p>
@@ -422,4 +460,119 @@
 =======
     <a href="/"><button>Back</button></a>
 >>>>>>> adds working per-ethereum-address ui, uniswap sybil checking, and debug data to allow simple testing
+=======
+	{#if errorMessage}
+		<div class="error-container">
+			<p style="color:red">{errorMessage}</p>
+		</div>
+	{/if}
+	<!-- TODO: REMOVE THIS AS DEBUG  -->
+	<div>
+		<p style="color:red">Debug Mock Data</p>
+		<button
+			on:click={() => {
+				console.log("IN ON CLICK");
+				debugUIData();
+			}}>Start Debug</button
+		>
+	</div>
+	<div>
+		<label for="currentAddress">Choose An Address</label>
+		<select bind:value={currentAddress} name="currentAddress">
+			<option value="">No Address Selected</option>
+			{#each Object.keys(uniswapVCStatusMap) as wallet}
+				{#if uniswapVCStatusMap[wallet].live}
+					<option value={wallet}>{wallet}</option>
+				{:else}
+					<option value={wallet}>{wallet} (Not Connected)</option>
+				{/if}
+			{/each}
+		</select>
+	</div>
+	{#if currentAddress}
+		{#if loading}
+			<p>Updating...</p>
+		{:else}
+			<!-- TODO ITER OVER STATUS TO CHANGE BUTTON STATE.-->
+			<div class="btn-group">
+				<button
+					on:click={() => {
+						// TODO: IMPLEMENT
+						alert("Turn into Link");
+					}}>Show 30-Day Trade History</button
+				>
+				<button
+					on:click={() => {
+						// TODO: IMPLEMENT
+						alert("Turn into Link");
+					}}>Show 30-Day LP History</button
+				>
+
+				{#if uniswapVCStatusMap[currentAddress].status.activity.cached}
+					<button
+						on:click={() => {
+							// TODO: IMPLEMENT
+							alert("Issue activity credential");
+						}}>Issue Trade Activity Credential</button
+					>
+				{:else if !uniswapVCStatusMap[currentAddress].live && uniswapVCStatusMap[currentAddress].status.activity.cached}
+					<button disabled={true}>Create Trade Activity Credential</button>
+					<p style="color:white">
+						Cannot create new credential with disconnected wallet
+					</p>
+				{:else}
+					<button
+						on:click={() => {
+							// TODO: IMPLEMENT
+							alert("Query Uniswap API then Create activity credential");
+						}}>Create Trade Activity Credential</button
+					>
+				{/if}
+
+				{#if uniswapVCStatusMap[currentAddress].status.liquidity.cached}
+					<button
+						on:click={() => {
+							// TODO: IMPLEMENT
+							alert("Issue liquidity credential");
+						}}>Issue LP Credential</button
+					>
+				{:else if !uniswapVCStatusMap[currentAddress].live}
+					<button disabled>Create LP Credential</button>
+					<p style="color:white">
+						Cannot create new credential with disconnected wallet
+					</p>
+				{:else}
+					<button
+						on:click={() => {
+							// TODO: IMPLEMENT
+							alert("Query Uniswap API then Create liquidity credential");
+						}}>Create LP Credential</button
+					>
+				{/if}
+
+				{#if uniswapVCStatusMap[currentAddress].status.sybil.cached}
+					<button
+						on:click={() => {
+							// TODO: IMPLEMENT
+							alert("Issue sybil credential");
+						}}>Issue Sybil Credential</button
+					>
+				{:else if !uniswapVCStatusMap[currentAddress].live}
+					<button disabled>Create Trade Sybil Credential</button>
+					<p style="color:white">
+						Cannot create new credential with disconnected wallet
+					</p>
+				{:else}
+					<button
+						on:click={() => {
+							// TODO: IMPLEMENT
+							issueSybilVC(currentAddress);
+						}}>Create Trade Sybil Credential</button
+					>
+				{/if}
+			</div>
+		{/if}
+	{/if}
+	<a href="/"><button>Back</button></a>
+>>>>>>> updated to include qualifications in state to best show the UI for live accounts
 </main>

--- a/src/uniswap.js
+++ b/src/uniswap.js
@@ -208,25 +208,16 @@ const isValidSybilEntry = (entry) => {
 	cred: JSON Value, // the specific details for a property in the credentialSubject
 	credKey: string, // the key at which cred is found in the credentialSubject
 	credType: string, // the type to be used in the VC type array.
-	credSubjectContext: string | false, // the context to be used in the Credential Subject @context
 	credVCContext: string | false, // the context to be used in the VC @context.
 	credVCID: string | false, // the id of the VC.
 }
 */
 export const makeEthVC = (wallet, credOpts, proof) => {
-	let { cred, credKey, credType, credVCContext, credSubjectContext, credVCID } = credOpts;
+	let { cred, credKey, credType, credVCContext,  credVCID } = credOpts;
 
 	let credentialSubject = {
 		"@context": ["https://w3id.org/did/v1"],
 		id: `did:ethr:${wallet}`,
-		publicKey: [
-			{
-				id: `did:ethr:${wallet}#owner`,
-				type: "Secp256k1VerificationKey2018",
-				owner: `did:ethr:${wallet}`,
-				ethereumAddress: wallet,
-			},
-		],
 		authentication: [
 			{
 				type: "Secp256k1SignatureAuthentication2018",
@@ -236,9 +227,6 @@ export const makeEthVC = (wallet, credOpts, proof) => {
 	};
 
 	credentialSubject[credKey] = cred;
-	if (credSubjectContext) {
-		credentialSubject["@context"].push(credSubjectContext);
-	}
 
 	let vc = {
 		"@context": [
@@ -267,7 +255,6 @@ export const makeUniswapSybilVC = (wallet, cred, proof) => {
 		credKey: "sybil",
 		credType: "UniswapSybilCredential",
 		// TODO: Define the below:
-		credSubjectContext: false,
 		credVCContext: false,
 		credVCID: false
 	};
@@ -280,7 +267,6 @@ export const makeUniswapTradeActivityVC = (wallet, cred, proof) => {
 		credKey: "activity",
 		credType: "UniswapTradeActivityCredential",
 		// TODO: Define the below:
-		credSubjectContext: false,
 		credVCContext: false,
 		credVCID: false
 	};
@@ -293,7 +279,6 @@ export const makeUniswapLiquidityVC = (wallet, cred, proof) => {
 		credKey: "liquidity",
 		credType: "UniswapLiquidityCredential",
 		// TODO: Define the below:
-		credSubjectContext: false,
 		credVCContext: false,
 		credVCID: false
 	};

--- a/src/uniswap.js
+++ b/src/uniswap.js
@@ -99,7 +99,7 @@ const uniswapQuery = gql`
 		query getTransactions($wallet: String!, $daysBack: Int!) {
 			transactions(where: {user: $wallet, timestamp_gt: $daysBack}) {
 				id
-				tokenAddress
+				user
 				timestamp
 				addLiquidityEvents {
 					id
@@ -143,6 +143,8 @@ const sendActivityQuery = async (wallet, daysBack) => {
 /* Sybil */
 const uniswapSybilListURL = "https://raw.githubusercontent.com/Uniswap/sybil-list/master/verified.json";
 
+// TODO: Change this to just do the VC making signing with a proof?
+// Decoupled from fetch.
 export const createSybilVC = async (wallet, signingFn) => {
 	let entry, success;
 	try {

--- a/src/uniswap.js
+++ b/src/uniswap.js
@@ -131,7 +131,6 @@ const sendActivityQuery = async (wallet, daysBack) => {
 		}
 
 		let result = await request(uniswapAPIEndpoint, uniswapQuery, queryArgs);
-		console.log("HERE I");
 		return [true, result];
 	} catch (_err) {
 		let errMsg = "Failed to reach uniswap API";

--- a/src/util/Uniswap.js
+++ b/src/util/Uniswap.js
@@ -1,0 +1,123 @@
+const uniswapSybilListURL = "https://raw.githubusercontent.com/Uniswap/sybil-list/master/verified.json";
+
+export const createSybilVC = async (wallet, signingFn) => {
+    let entry;
+    try {
+        entry = await sybilVerifyRequest(wallet);
+    } catch (err) {
+        let errorMsg = `Failed to verify wallet: ${err}`;
+        return [false, errorMsg];
+    }
+
+    let [success, jws] = signingFn(JSON.stringify(credentialSubject));
+    // Only fails if account is locked.
+    if (!success) {
+        return [false, jws];
+    }
+
+    let proof = makeSybilProof(wallet, jws);
+
+    let vc = makeSybilCredential(wallet, entry, proof);
+
+    return [true, vc];
+};
+
+// TODO: Verify format
+const makeSybilProof = (wallet, jws) => {
+    return {
+        type: "Secp256k1SignatureAuthentication2018",
+        // TODO: Fmt?
+        created: Date.now(),
+        proofPurpose: "assertionMethod",
+        verificationMethod: `did:ethr:${wallet}`,
+        jws: jws,
+    };
+}
+
+// Currently uses Uniswap's list.
+// Could change to a method that directory queries twitter from tweetID.
+const sybilVerifyRequest = async (wallet) => {
+    try {
+        let res = await fetch(
+            uniswapSybilListURL
+        );
+
+        if (!res.ok || res.status !== 200) {
+            throw "Bad response from Sybil List";
+        }
+
+        let json = await res.json();
+        if (!json || typeof json !== "object") {
+            throw "Bad response from Sybil List";
+        }
+
+        let entry = json[wallet];
+        if (!isValidSybilEntry(entry)) {
+            throw "Valid entry not found in Sybil List";
+        }
+
+        return [true, entry];
+    } catch (_err) {
+        // Could use err here, or is it better to be vague?
+        return [false, "Error in Uniswap Sybil Verification"];
+    }
+};
+
+const isValidSybilEntry = (entry) => {
+    let isObject = entry && typeof entry === "object";
+    if (!isObject) {
+        return false;
+    }
+
+    let hasTwitterEntry =
+        entry.twitter && typeof entry.twitter === "object";
+    if (!hasTwitterEntry) {
+        return false;
+    }
+
+    let { twitter } = entry;
+
+    let hasTimestamp =
+        twitter.timestamp && typeof twitter.timestamp === "number";
+    let hasTweetID = twitter.tweetID && typeof twitter.tweetID === "string";
+    let hasHandle = twitter.handle && typeof twitter.handle === "string";
+
+    return hasTimestamp && hasTweetID && hasHandle;
+};
+
+const makeSybilCredential = (wallet, cred, proof) => {
+    let credentialSubject = {
+        "@context": "https://w3id.org/did/v1",
+        id: `did:ethr:${wallet}`,
+        publicKey: [
+            {
+                id: `did:ethr:${wallet}#owner`,
+                type: "Secp256k1VerificationKey2018",
+                owner: `did:ethr:${wallet}`,
+                ethereumAddress: wallet,
+            },
+        ],
+        authentication: [
+            {
+                type: "Secp256k1SignatureAuthentication2018",
+                publicKey: `did:ethr:${wallet}#owner`,
+            },
+        ],
+        sybil: cred,
+    };
+
+    let vc = {
+        "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            // TODO: Add specific context?
+        ],
+        // !NOTE What does this need to be?
+        // id: "http://example.edu/credentials/3732",
+        issuer: credentialSubject.id,
+        type: ["VerifiableCredential", "UniswapSybilCredential"],
+        credentialSubject: credentialSubject,
+        proof: proof,
+    };
+
+    return vc;
+};


### PR DESCRIPTION
What this PR does:
* Adds a Uniswap UI that meets our Figma requirements. 
* Implements a Dropdown of ETH addresses, that when selected are tested for qualifications (activity, liquidity, and sybil) that can be used to issue VCs.
* Correctly presents the end user with only valid options for credential caching and issuence based on internal app state (and caching).
* Includes a uniswap.js helper library for querying trade activity/liquidity/sybil memebership of a given ETH wallet.
* Includes general functions to generate custom ETH based VCs from the qualifications found in earlier steps (though they are incomplete).
* Caches VCs in localStorage so that qualifications do not have to repetitively retrieved.  
* Includes a debug data mode with real ETH addresses to verify that the qualification logic works as expected and allows testing of the code paths.

What this PR does NOT do:
* Does not populate the dropdown with connected ETH wallets (this functionality is in Unicred.svelte -> onLoad, but it is not hooked into onMount lifecycle yet, because it requires an active `ethereum` Metamask object to be passed in, once that is supplied, it should "just work")
* Does not sign the VC proof section with a JWS as it should (again, requires the `ethereum` object).
* Does not make the QR code presentation of a VC once a VC is cached.

Happy to make any changes/address any oversights.