### PR TITLE
Get user's DID using CHAPI/DIDAuth

### DIFF
--- a/src/CredentialWallet.js
+++ b/src/CredentialWallet.js
@@ -1,0 +1,58 @@
+import * as polyfill from 'credential-handler-polyfill';
+
+// The user's id, as a reactive store
+// https://svelte.dev/docs#Store_contract
+export let id = {
+	id: null,
+	subscribers: [],
+	set: function (id) {
+		this.id = id;
+		this.subscribers.forEach(fn => fn(id));
+	},
+	subscribe: function (fn) {
+		this.subscribers.push(fn);
+		fn(this.id);
+		return () => {
+			const i = this.subscribers.indexOf(fn);
+			if (i > -1) this.subscribers.splice(i, 1);
+		}
+	}
+};
+
+// Request the user's id, using DIDAuth over CHAPI, without verification.
+// Updates the exported id store and returns the id.
+export async function connect() {
+	await polyfill.loadOnce();
+	const credentialQuery = {
+		web: {
+			VerifiablePresentation: {
+				query: [{type: "DIDAuth"}]
+			}
+		}
+	};
+	const webCredential = await navigator.credentials.get(credentialQuery);
+	if (!webCredential) {
+		throw new Error("Unable to connect to credential wallet");
+	}
+	if (webCredential.type !== 'web') {
+		console.error(webCredential)
+		throw new Error("Unexpected web credential type: " + webCredential.type);
+	}
+	if (webCredential.dataType !== 'VerifiablePresentation') {
+		console.error(webCredential)
+		throw new Error("Unexpected web credential data type: " + webCredential.dataType);
+	}
+	const vp = webCredential.data;
+	if (!vp) {
+		console.error(webCredential)
+		throw new Error("Missing web credential data");
+	}
+	// Skip verifying the VP and just trust the wallet.
+	const holder = vp.holder;
+	if (!holder) {
+		console.error(webCredential)
+		throw new Error("Missing verifiable presentation holder");
+	}
+	id.set(holder)
+	return holder;
+}

--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -8,6 +8,7 @@
     import Unicred from "../routes/Unicred.svelte";
     import Srmcred from "../routes/Srmcred.svelte";
     import Home from "../routes/Home.svelte";
+    import Credwallet from "../routes/Credwallet.svelte";
 
     let Route,
         params = {},
@@ -26,6 +27,7 @@
         .on("/Solcontrol", () => (Route = Solcontrol))
         .on("/Unicred", () => (Route = Unicred))
         .on("/Srmcred", () => (Route = Srmcred))
+        .on("/Credwallet", () => (Route = Credwallet))
         .listen();
 
     onDestroy(router.unlisten);

--- a/src/components/BaseLayout.svelte
+++ b/src/components/BaseLayout.svelte
@@ -3,10 +3,33 @@
     import Menu from "./Menu.svelte";
     export let title;
     export let icon;
+    export let allowUnauthed = false;
+    import {id} from "../CredentialWallet.js";
 </script>
+
+<style>
+.content {
+    max-width: 72ex;
+    color: #eee;
+    margin: 0 auto;
+}
+a {
+    text-decoration: underline;
+}
+p {
+    margin: 1em 0;
+}
+</style>
 
 <div class="flex flex-col flex-grow z-10">
     <Menu />
     <IconTitle {title} {icon} />
-    <slot />
+    {#if $id || allowUnauthed}
+        <slot />
+    {:else}
+        <div class="content">
+            <p>Please connect your credential wallet first.</p>
+            <p><a href="/">Back</a></p>
+        </div>
+    {/if}
 </div>

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -2,9 +2,24 @@
     export let label;
     export let icon;
     export let href;
+    export let disabled = false;
 </script>
 
-<a {href} class="max-w-sm mx-auto my-2 w-full">
+<style>
+.disabled {
+    opacity: 0.5;
+}
+.disabled button {
+    cursor: default;
+}
+.disabled button:focus {
+    outline: none;
+}
+</style>
+
+<a href={disabled ? null : href}
+    class="max-w-sm mx-auto my-2 w-full" class:disabled
+>
     <button
         class="bg-blue-990 text-white py-4 text-left rounded-2xl font-semibold flex items-center w-full h-18"
     >

--- a/src/components/IconTitle.svelte
+++ b/src/components/IconTitle.svelte
@@ -4,7 +4,9 @@
 </script>
 
 <div class="flex flex-col items-center justify-center">
-    <img src={icon} alt="{title}-icon" class="w-16 h-16" />
+    {#if icon}
+        <img src={icon} alt="{title}-icon" class="w-16 h-16" />
+    {/if}
     <h1
         class="md:mt-12 md:mb-16 mb-4 font-semibold text-6xl text-white text-center"
     >

--- a/src/routes/Credwallet.svelte
+++ b/src/routes/Credwallet.svelte
@@ -1,0 +1,51 @@
+<script>
+	import BaseLayout from "../components/BaseLayout.svelte";
+	import SecondaryButton from "../components/SecondaryButton.svelte";
+	import * as CredentialWallet from "../CredentialWallet.js";
+
+	let errorMessage;
+	let statusMessage;
+
+	async function connectWallet() {
+		statusMessage = "Waiting for Credential Wallet...";
+		try {
+			await CredentialWallet.connect();
+			statusMessage = "Connected.";
+		} catch(err) {
+			statusMessage = "";
+			console.error(err);
+			errorMessage = err.message;
+		}
+	}
+</script>
+
+<style>
+	.content {
+		max-width: 72ex;
+		color: #eee;
+		margin: 0 auto;
+	}
+	.error {
+		color: red;
+	}
+	a {
+		text-decoration: underline;
+	}
+	p {
+		margin: 1em 0;
+	}
+</style>
+
+<BaseLayout title="Connect Credential Wallet" allowUnauthed=true>
+	{#if errorMessage}
+		<div class="content">
+			<p class="error">{errorMessage}</p>
+		</div>
+	{/if}
+	{#if statusMessage}
+		<p class="content">{statusMessage}</p>
+	{:else}
+		<SecondaryButton label="Connect Wallet" onClick={connectWallet} />
+	{/if}
+	<p class="content"><a href="/">Back</a>
+</BaseLayout>

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -1,6 +1,7 @@
 <script>
 	import RouteLayout from "../components/RouteLayout.svelte";
-import Button from "./../components/Button.svelte";
+	import Button from "./../components/Button.svelte";
+	import {id} from "../CredentialWallet.js";
 </script>
 
 <RouteLayout>
@@ -12,20 +13,29 @@ import Button from "./../components/Button.svelte";
 			Degen Passport
 		</h1>
 		<Button
+			href="/Credwallet"
+			label="Connect Credential Wallet"
+		/>
+		<Button
 			href="/Ethcontrol"
 			label="Ethereum Address Controller"
-			icon="/ethereum.svg"
+			disabled={!$id}
 		/>
 		<Button
 			href="/Solcontrol"
 			label="Solana Address Controller"
-			icon="/solana.svg"
+			disabled={!$id}
 		/>
 		<Button
 			href="/Unicred"
 			label="Uniswap Credentials"
 			icon="/uniswap.svg"
+			disabled={!$id}
 		/>
-		<Button href="/Srmcred" label="Serum Credentials" icon="/serum.svg" />
+		<Button
+			href="/Srmcred"
+			label="Serum Credentials"
+			disabled={!$id}
+		/>
 	</div>
 </RouteLayout>


### PR DESCRIPTION
Fix #8

This adds a Connect Credential Wallet button and page. On this page, the app makes a [DIDAuth](https://w3c-ccg.github.io/vp-request-spec/#did-authentication-request) request over [CHAPI](https://w3c-ccg.github.io/credential-handler-api/). The user's DID is retrieved from the response. That DID is then used as the [credentialSubject](https://w3c.github.io/vc-data-model/#credential-subject) for the credentials that the app will issue. The other buttons are disabled until the wallet has been connected, since we don't otherwise know the user's DID for their CHAPI wallet. Even though the [DIDAuth response](https://w3c-ccg.github.io/vp-request-spec/#example-4-a-didauth-response) is a VerifiablePresentation, we are just using it here to get the DID (presentation holder property) and not verifying the proof, since we assume the credential wallet is trusted.

This just updates the Ethcontrol credential issuance; updating the Uniswap credential issuance to use the DID from CHAPI Credential Wallet is not yet done.

![home-connect-credential-wallet.png](https://user-images.githubusercontent.com/95347/109243705-64d92f00-77ab-11eb-8b23-c440687415ca.png)

![connect-credential-wallet.png](https://user-images.githubusercontent.com/95347/109243877-b41f5f80-77ab-11eb-9370-e9e27e96f079.png)

![chapi-request.png](https://user-images.githubusercontent.com/95347/109243661-52f78c00-77ab-11eb-8a62-48ae9eb98c16.png)