### PR TITLE
Set proofPurpose for Ethcontrol VC

### DIFF
--- a/src/routes/EthcontrolIssue.svelte
+++ b/src/routes/EthcontrolIssue.svelte
@@ -53,7 +53,8 @@
 				}
 			};
 			const proofOptions = {
-					verificationMethod: did + "#Eip712Method2021"
+				verificationMethod: did + "#Eip712Method2021",
+				proofPurpose: "assertionMethod"
 			};
 			const keyType = {"kty":"EC","crv":"secp256k1","alg":"ES256K-R"};
 			statusMessage = "Preparing credential...";


### PR DESCRIPTION
Proof should have a [proofPurpose](https://w3c-ccg.github.io/security-vocab/#proofPurpose). [assertionMethod](https://w3c-ccg.github.io/security-vocab/#assertionMethod) is usually used for VC LDPs.